### PR TITLE
Link to the official Minecraft Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Screenshot of Custom LAN](docs/open_to_lan_screen.png)
 A **Fabric** mod that allows you to:
 * Customize more of your integrated server (Online Mode, PvP, Max Players, MOTD)
-* Use ampersands (`&`) for [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) instead of section signs (`§`) and variables (e.g. `${username}`, `${world}`) in the MOTD
+* Use ampersands (`&`) for [formatting codes](https://minecraft.wiki/w/Formatting_codes) instead of section signs (`§`) and variables (e.g. `${username}`, `${world}`) in the MOTD
 * Change the settings mid-game (including the port) and stop the server without quitting the world
 * Save the settings globally or per-world (they are loaded automatically with per-world settings taking priority over the global ones, which take priority over the system defaults)
 * Change who can use cheats individually using the `/op` and `/deop` commands and cheat in singleplayer without opening to LAN (replaces the Allow Cheats button)
@@ -22,7 +22,7 @@ It has been backported to all Minecraft versions supported by Fabric (except the
 I'm **not** planning on porting it to **Forge** myself *for now,* but you're more than welcome to send me a pull request.
 
 ## Explanation of MOTD formatting codes and variables
-In the MOTD, ampersands (`&`) are replaced with section signs (`§`) to allow you to enter [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) (e.g. `&9Hello, &a&lworld!` makes `Hello,` blue and `world!` green and bold).
+In the MOTD, ampersands (`&`) are replaced with section signs (`§`) to allow you to enter [formatting codes](https://minecraft.wiki/w/Formatting_codes) (e.g. `&9Hello, &a&lworld!` makes `Hello,` blue and `world!` green and bold).
 You can use two ampersands in a row (`&&`) to get an actual ampersand (`&`).
 
 The following variables will be expanded using [Apache Commons Text's `StringSubstitutor`](https://commons.apache.org/proper/commons-text/apidocs/org/apache/commons/text/StringSubstitutor.html):

--- a/src/main/java/com/dimitrodam/customlan/mixin/OpenToLanScreenMixin.java
+++ b/src/main/java/com/dimitrodam/customlan/mixin/OpenToLanScreenMixin.java
@@ -299,7 +299,7 @@ public abstract class OpenToLanScreenMixin extends Screen {
         // MOTD field
         this.motdField = new TextFieldWidget(this.textRenderer, this.width / 2 - 154, this.height - 54, 308, 20,
                 MOTD_TEXT);
-        motdField.setMaxLength(59); // https://minecraft.fandom.com/wiki/Server.properties#motd
+        motdField.setMaxLength(59); // https://minecraft.wiki/w/Server.properties#motd
         motdField.setText(this.rawMotd);
         motdField.setTooltip(
                 Tooltip.of(Text.literal(CustomLan.processMotd(server, MOTD_DESCRIPTION_TEXT.getString()))));


### PR DESCRIPTION
This updates the README.md to link to the new Minecraft wiki instead of the legacy Fandom wiki. Note that this only does so on the 1.20.2 version's branch, you'll have to apply the same change on other branches.